### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add original error message to `PackrinthErrror::FailedToSerialize`
 - [**breaking**] When an error is shown, the original error message containing more information is shown more often
 
-### Fixed
+### Changed
 
-- Move the `default` function of `BranchFiles` to trait `Default`
+- [**breaking**] Move the `default` function of `BranchFiles` to trait `Default`
+
+### Other
+
+- Add documentation to library structs and functions
 
 ## [0.2.1](https://github.com/Thijzert123/packrinth/compare/v0.2.0...v0.2.1) - 2025-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/Thijzert123/packrinth/compare/v0.2.1...v0.3.0) - 2025-09-04
+
+### Added
+
+- Add original error message to `PackrinthErrror::FailedToSerialize`
+- [**breaking**] When an error is shown, the original error message containing more information is shown more often
+
+### Fixed
+
+- Move the `default` function of `BranchFiles` to trait `Default`
+
 ## [0.2.1](https://github.com/Thijzert123/packrinth/compare/v0.2.0...v0.2.1) - 2025-09-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,7 +2165,7 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "packrinth"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "clap-markdown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["cli", "minecraft", "modpack", "modrinth"]
 categories = ["command-line-utilities", "development-tools"]
 authors = ["Thijzert <184778919+Thijzert123@users.noreply.github.com>"]
 license = "MIT"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 include = ["src/", "*.md"]
 


### PR DESCRIPTION



## 🤖 New release

* `packrinth`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `packrinth` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_missing.ron

Failed in:
  enum packrinth::config::Side, previously in file /tmp/.tmpbE4pxT/packrinth/src/config.rs:215

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant PackrinthError::PathIsFile in /tmp/.tmppKr5v1/packrinth/src/lib.rs:25
  variant PackrinthError::FailedToCreateDir in /tmp/.tmppKr5v1/packrinth/src/lib.rs:28
  variant PackrinthError::FailedToReadToString in /tmp/.tmppKr5v1/packrinth/src/lib.rs:32
  variant PackrinthError::FailedToParseConfigJson in /tmp/.tmppKr5v1/packrinth/src/lib.rs:36
  variant PackrinthError::FailedToParseModrinthResponseJson in /tmp/.tmppKr5v1/packrinth/src/lib.rs:40
  variant PackrinthError::ProjectIsNotAdded in /tmp/.tmppKr5v1/packrinth/src/lib.rs:47
  variant PackrinthError::OverrideDoesNotExist in /tmp/.tmppKr5v1/packrinth/src/lib.rs:50
  variant PackrinthError::NoOverridesForProject in /tmp/.tmppKr5v1/packrinth/src/lib.rs:54
  variant PackrinthError::NoExclusionsForProject in /tmp/.tmppKr5v1/packrinth/src/lib.rs:57
  variant PackrinthError::NoInclusionsForProject in /tmp/.tmppKr5v1/packrinth/src/lib.rs:60
  variant PackrinthError::ProjectAlreadyHasExclusions in /tmp/.tmppKr5v1/packrinth/src/lib.rs:63
  variant PackrinthError::ProjectAlreadyHasInclusions in /tmp/.tmppKr5v1/packrinth/src/lib.rs:66
  variant PackrinthError::FailedToWriteFile in /tmp/.tmppKr5v1/packrinth/src/lib.rs:69
  variant PackrinthError::FailedToInitializeFileType in /tmp/.tmppKr5v1/packrinth/src/lib.rs:73
  variant PackrinthError::DirectoryExpected in /tmp/.tmppKr5v1/packrinth/src/lib.rs:77
  variant PackrinthError::FailedToStartZipFile in /tmp/.tmppKr5v1/packrinth/src/lib.rs:80
  variant PackrinthError::FailedToWriteToZip in /tmp/.tmppKr5v1/packrinth/src/lib.rs:84
  variant PackrinthError::FailedToGetWalkDirEntry in /tmp/.tmppKr5v1/packrinth/src/lib.rs:88
  variant PackrinthError::FailedToStripPath in /tmp/.tmppKr5v1/packrinth/src/lib.rs:91
  variant PackrinthError::FailedToAddZipDir in /tmp/.tmppKr5v1/packrinth/src/lib.rs:95
  variant PackrinthError::BranchDoesNotExist in /tmp/.tmppKr5v1/packrinth/src/lib.rs:99
  variant PackrinthError::NoModrinthFilesFoundForProject in /tmp/.tmppKr5v1/packrinth/src/lib.rs:104
  variant PackrinthError::RequestFailed in /tmp/.tmppKr5v1/packrinth/src/lib.rs:107
  variant PackrinthError::FailedToGetCurrentDirectory in /tmp/.tmppKr5v1/packrinth/src/lib.rs:111
  variant PackrinthError::InvalidPackFormat in /tmp/.tmppKr5v1/packrinth/src/lib.rs:114
  variant PackrinthError::FailedToInitGitRepoWhileInitModpack in /tmp/.tmppKr5v1/packrinth/src/lib.rs:121
  variant PackrinthError::ModpackAlreadyExists in /tmp/.tmppKr5v1/packrinth/src/lib.rs:124

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant PackrinthError::FailedToSerialize in /tmp/.tmppKr5v1/packrinth/src/lib.rs:44

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  Modpack::add_project_override, previously in file /tmp/.tmpbE4pxT/packrinth/src/config.rs:310
  Modpack::remove_project_override, previously in file /tmp/.tmpbE4pxT/packrinth/src/config.rs:332
  Modpack::remove_all_project_overrides, previously in file /tmp/.tmpbE4pxT/packrinth/src/config.rs:356

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  packrinth::config::BranchFiles::default now takes 0 parameters instead of 2, in /tmp/.tmppKr5v1/packrinth/src/config.rs:1061
  packrinth::config::Modpack::new now takes 2 parameters instead of 1, in /tmp/.tmppKr5v1/packrinth/src/config.rs:274

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  MODPACK_CONFIG_FILE_NAME in file /tmp/.tmpbE4pxT/packrinth/src/config.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/Thijzert123/packrinth/compare/v0.2.1...v0.3.0) - 2025-09-04

### Added

- Add original error message to `PackrinthErrror::FailedToSerialize`
- [**breaking**] When an error is shown, the original error message containing more information is shown more often

### Fixed

- Move the `default` function of `BranchFiles` to trait `Default`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).